### PR TITLE
fixed non valid password error message

### DIFF
--- a/npm-user-validate.js
+++ b/npm-user-validate.js
@@ -9,7 +9,7 @@ var requirements = exports.requirements = {
     dot: 'Username may not start with "."'
   },
   password: {
-    badchars: 'Password passwords cannot contain these characters: \'!:@"'
+    badchars: 'Password cannot contain these characters: \'!:@"'
   },
   email: {
     valid: 'Email must be an email address'


### PR DESCRIPTION
When creating a npmjs.org user, I was prompted "Password passwords cannot contain these characters", which is not grammatically correct!
