### PR TITLE
fix: added regex for blocking illegal characters in usernames

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ coverage.html
 lib-cov
 
 node_modules
+.nyc_output

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,4 @@ sudo: false
 node_js:
   - "0.8"
   - "0.10"
+  - node

--- a/npm-user-validate.js
+++ b/npm-user-validate.js
@@ -17,7 +17,7 @@ var requirements = exports.requirements = {
 
 var illegalCharacterRe = new RegExp('([' + [
   "'"
-].join(',') + '])')
+].join() + '])')
 
 function username (un) {
   if (un !== un.toLowerCase()) {

--- a/npm-user-validate.js
+++ b/npm-user-validate.js
@@ -1,19 +1,23 @@
 exports.email = email
 exports.pw = pw
 exports.username = username
-
 var requirements = exports.requirements = {
   username: {
     length: 'Name length must be less than or equal to 214 characters long',
     lowerCase: 'Name must be lowercase',
     urlSafe: 'Name may not contain non-url-safe chars',
-    dot: 'Name may not start with "."'
+    dot: 'Name may not start with "."',
+    illegal: 'Name may not contain illegal character'
   },
   password: {},
   email: {
     valid: 'Email must be an email address'
   }
-};
+}
+
+var illegalCharacterRe = new RegExp('([' + [
+  "'"
+].join(',') + '])')
 
 function username (un) {
   if (un !== un.toLowerCase()) {
@@ -30,6 +34,11 @@ function username (un) {
 
   if (un.length > 214) {
     return new Error(requirements.username.length)
+  }
+
+  var illegal = un.match(illegalCharacterRe)
+  if (illegal) {
+    return new Error(requirements.username.illegal + ' "' + illegal[0] + '"')
   }
 
   return null

--- a/package.json
+++ b/package.json
@@ -4,10 +4,13 @@
   "description": "User validations for npm",
   "main": "npm-user-validate.js",
   "devDependencies": {
-    "tap": "^1.2.0"
+    "standard": "^8.4.0",
+    "standard-version": "^3.0.0",
+    "tap": "^7.1.2"
   },
   "scripts": {
-    "test": "tap test/*.js"
+    "pretest": "standard",
+    "test": "tap --100 test/*.js"
   },
   "repository": {
     "type": "git",

--- a/test/email.test.js
+++ b/test/email.test.js
@@ -2,25 +2,25 @@ var test = require('tap').test
 var v = require('../npm-user-validate.js').email
 
 test('email misses an @', function (t) {
-  err = v('namedomain')
+  var err = v('namedomain')
   t.type(err, 'object')
   t.end()
 })
 
 test('email misses a dot', function (t) {
-  err = v('name@domain')
+  var err = v('name@domain')
   t.type(err, 'object')
   t.end()
 })
 
 test('email misses a string before the @', function (t) {
-  err = v('@domain')
+  var err = v('@domain')
   t.type(err, 'object')
   t.end()
 })
 
 test('email is ok', function (t) {
-  err = v('name@domain.com')
+  var err = v('name@domain.com')
   t.type(err, 'null')
   t.end()
 })

--- a/test/pw.test.js
+++ b/test/pw.test.js
@@ -2,31 +2,31 @@ var test = require('tap').test
 var v = require('../npm-user-validate.js').pw
 
 test('pw contains a \'', function (t) {
-  err = v('\'')
+  var err = v('\'')
   t.type(err, 'null')
   t.end()
 })
 
 test('pw contains a :', function (t) {
-  err = v(':')
+  var err = v(':')
   t.type(err, 'null')
   t.end()
 })
 
 test('pw contains a @', function (t) {
-  err = v('@')
+  var err = v('@')
   t.notOk(err, 'null')
   t.end()
 })
 
 test('pw contains a "', function (t) {
-  err = v('"')
+  var err = v('"')
   t.type(err, 'null')
   t.end()
 })
 
 test('pw is ok', function (t) {
-  err = v('duck')
+  var err = v('duck')
   t.type(err, 'null')
   t.end()
 })

--- a/test/username.test.js
+++ b/test/username.test.js
@@ -15,6 +15,13 @@ test('username may not contain non-url-safe chars', function (t) {
   t.end()
 })
 
+test('username may not contain illegal characters', function (t) {
+  var err = v("ben's")
+  t.type(err, 'object')
+  t.match(err.message, /illegal character "'"/)
+  t.end()
+})
+
 test('username may not start with "."', function (t) {
   var err = v('.username')
   t.type(err, 'object')
@@ -27,13 +34,13 @@ test('username may not be longer than 214 characters', function (t) {
   t.type(err, 'object')
   t.match(err.message, /less than or equal to 214/)
   t.end()
-});
+})
 
 test('username may be as long as 214 characters', function (t) {
   var err = v('bacon-ipsum-dolor-amet-tongue-short-loin-landjaeger-tenderloin-ball-tip-pork-loin-porchetta-pig-pork-chop-beef-ribs-pork-belly--shankle-t-bone-turducken-tongue-landjaeger-pork-loin-beef-chicken-short-loin-porchetta')
   t.type(err, 'null')
   t.end()
-});
+})
 
 test('username is ok', function (t) {
   var err = v('ente')


### PR DESCRIPTION
## The Problem

We ran into an issue recently where single-quotes (`'`) were accepted by `npm-user-validate`, but rejected by CouchDB.

Linux and OSX systems do not play nice with `'` in folder paths; and I think the correct solution is black-listing this character.
## The Solution

I've added a regex that allows us to black-list specific illegal characters, starting with `'`.

To make sure I was writing appropriate tests, etc., I've upgraded `tap` and turned on coverage; I've also added Travis CI testing for modern Node.js.
