### PR TITLE
allow uri-safe usernames (Closes #12)

### DIFF
--- a/npm-user-validate.js
+++ b/npm-user-validate.js
@@ -24,7 +24,7 @@ function username (un) {
     return new Error(requirements.username.lowerCase)
   }
 
-  if (un !== encodeURIComponent(un)) {
+  if (un !== encodeURIComponent(decodeURIComponent(un))) {
     return new Error(requirements.username.urlSafe)
   }
 

--- a/test/username.test.js
+++ b/test/username.test.js
@@ -47,3 +47,9 @@ test('username is ok', function (t) {
   t.type(err, 'null')
   t.end()
 })
+
+test('uri-safe email address is ok', function (t) {
+  var err = v('user%40domain.com')
+  t.type(err, 'null')
+  t.end()
+})


### PR DESCRIPTION
Email addresses are currently not supported as valid usernames as part of `npm login`, although some systems use email addresses for usernames.

Converting an email address to URI-safe doesn't currently pass validation because the `%` character is translated to `%25`.  This seems to be the simplest change that supports correctly URI-encoded usernames without breaking any of the existing tests.

This PR is blocked by https://github.com/npm/npm-profile/pull/6 as implementing this without that one will result in the inability to log in because the encoded username will be encoded again.

Closes #12 